### PR TITLE
Add tvOS scheme (and rename iOS scheme)

### DIFF
--- a/Library/UIKit/NibResource+UIKit.swift
+++ b/Library/UIKit/NibResource+UIKit.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UIKit
 
 public extension NibResource {
   /**

--- a/Library/UIKit/StoryboardResourceWithInitialController+UIKit.swift
+++ b/Library/UIKit/StoryboardResourceWithInitialController+UIKit.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UIKit
 
 public extension StoryboardResourceWithInitialController {
   /**

--- a/Library/UIKit/UIFont+FontResource.swift
+++ b/Library/UIKit/UIFont+FontResource.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UIKit
 
 public extension UIFont {
   /**

--- a/R.swift.Library.xcodeproj/project.pbxproj
+++ b/R.swift.Library.xcodeproj/project.pbxproj
@@ -474,7 +474,7 @@
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 9.1;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
 			name = Debug;
 		};
@@ -493,7 +493,7 @@
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 9.1;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
 			name = Release;
 		};
@@ -675,6 +675,7 @@
 				806E69A51C42BD9C00DE3A8B /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		806E69A61C42BD9C00DE3A8B /* Build configuration list for PBXNativeTarget "RswiftTests-tvOS" */ = {
 			isa = XCConfigurationList;
@@ -683,6 +684,7 @@
 				806E69A81C42BD9C00DE3A8B /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		D59246481C117A54007F94C7 /* Build configuration list for PBXProject "R.swift.Library" */ = {
 			isa = XCConfigurationList;

--- a/R.swift.Library.xcodeproj/project.pbxproj
+++ b/R.swift.Library.xcodeproj/project.pbxproj
@@ -7,6 +7,27 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		806E699C1C42BD9C00DE3A8B /* Rswift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 806E69921C42BD9C00DE3A8B /* Rswift.framework */; };
+		806E69A91C42BDDA00DE3A8B /* FileResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5E435AC1C3D00770091090C /* FileResource.swift */; };
+		806E69AA1C42BDDA00DE3A8B /* FontResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D57E1EB21C3D762300DDA68F /* FontResource.swift */; };
+		806E69AB1C42BDDA00DE3A8B /* Identifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D543F9BA1C1497EB00D16A0C /* Identifier.swift */; };
+		806E69AC1C42BDDA00DE3A8B /* NibResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D543F9C01C14984300D16A0C /* NibResource.swift */; };
+		806E69AD1C42BDDA00DE3A8B /* ReuseIdentifierProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = D543F9BC1C14980600D16A0C /* ReuseIdentifierProtocol.swift */; };
+		806E69AE1C42BDDA00DE3A8B /* StoryboardResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D57E1EB61C3E482A00DDA68F /* StoryboardResource.swift */; };
+		806E69AF1C42BDDA00DE3A8B /* StoryboardSegueIdentifierProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = D543F9BE1C14983100D16A0C /* StoryboardSegueIdentifierProtocol.swift */; };
+		806E69B01C42BDDA00DE3A8B /* Validatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D53F19231C229D7200AE2FAD /* Validatable.swift */; };
+		806E69B11C42BDE000DE3A8B /* NibResource+UIKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5E435A81C3CFB460091090C /* NibResource+UIKit.swift */; };
+		806E69B21C42BDE000DE3A8B /* StoryboardResourceWithInitialController+UIKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = D57E1EB81C3E4C1A00DDA68F /* StoryboardResourceWithInitialController+UIKit.swift */; };
+		806E69B31C42BDE000DE3A8B /* TypedStoryboardSegueInfo+UIStoryboardSegue.swift in Sources */ = {isa = PBXBuildFile; fileRef = D543F9CE1C149C0A00D16A0C /* TypedStoryboardSegueInfo+UIStoryboardSegue.swift */; };
+		806E69B41C42BDE000DE3A8B /* UICollectionView+ReuseIdentifierProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = D543F9C51C14992000D16A0C /* UICollectionView+ReuseIdentifierProtocol.swift */; };
+		806E69B51C42BDE000DE3A8B /* UIFont+FontResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D57E1EB41C3D774000DDA68F /* UIFont+FontResource.swift */; };
+		806E69B61C42BDE000DE3A8B /* UINib+NibResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5588CAA1C3F9DBE00912F97 /* UINib+NibResource.swift */; };
+		806E69B71C42BDE000DE3A8B /* UIStoryboard+StoryboardResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D57E1EBA1C3E4C4300DDA68F /* UIStoryboard+StoryboardResource.swift */; };
+		806E69B81C42BDE000DE3A8B /* UIStoryboardSegue+StoryboardSegueIdentifierProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = D543F9CB1C1499AB00D16A0C /* UIStoryboardSegue+StoryboardSegueIdentifierProtocol.swift */; };
+		806E69B91C42BDE000DE3A8B /* UITableView+ReuseIdentifierProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = D543F9C31C1498FB00D16A0C /* UITableView+ReuseIdentifierProtocol.swift */; };
+		806E69BA1C42BDE000DE3A8B /* UIViewController+NibResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D543F9C71C14995800D16A0C /* UIViewController+NibResource.swift */; };
+		806E69BB1C42BDE000DE3A8B /* UIViewController+StoryboardSegueIdentifierProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = D543F9C91C14998800D16A0C /* UIViewController+StoryboardSegueIdentifierProtocol.swift */; };
+		806E69BC1C42BDE300DE3A8B /* RswiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D592465D1C117A55007F94C7 /* RswiftTests.swift */; };
 		D53F19241C229D7200AE2FAD /* Validatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D53F19231C229D7200AE2FAD /* Validatable.swift */; };
 		D543F9BB1C1497EB00D16A0C /* Identifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D543F9BA1C1497EB00D16A0C /* Identifier.swift */; };
 		D543F9BD1C14980600D16A0C /* ReuseIdentifierProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = D543F9BC1C14980600D16A0C /* ReuseIdentifierProtocol.swift */; };
@@ -32,6 +53,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		806E699D1C42BD9C00DE3A8B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D59246451C117A54007F94C7 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 806E69911C42BD9C00DE3A8B;
+			remoteInfo = "Rswift-tvOS";
+		};
 		D592465A1C117A55007F94C7 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D59246451C117A54007F94C7 /* Project object */;
@@ -42,6 +70,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		806E69921C42BD9C00DE3A8B /* Rswift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Rswift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		806E699B1C42BD9C00DE3A8B /* RswiftTests-tvOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "RswiftTests-tvOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D53F19231C229D7200AE2FAD /* Validatable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Validatable.swift; sourceTree = "<group>"; };
 		D543F9BA1C1497EB00D16A0C /* Identifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Identifier.swift; sourceTree = "<group>"; };
 		D543F9BC1C14980600D16A0C /* ReuseIdentifierProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReuseIdentifierProtocol.swift; sourceTree = "<group>"; };
@@ -62,7 +92,7 @@
 		D592464E1C117A55007F94C7 /* Rswift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Rswift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D59246511C117A55007F94C7 /* Rswift.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Rswift.h; sourceTree = "<group>"; };
 		D59246531C117A55007F94C7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		D59246581C117A55007F94C7 /* RswiftTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RswiftTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		D59246581C117A55007F94C7 /* RswiftTests-iOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "RswiftTests-iOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D592465D1C117A55007F94C7 /* RswiftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RswiftTests.swift; sourceTree = "<group>"; };
 		D592465F1C117A55007F94C7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D5E435A81C3CFB460091090C /* NibResource+UIKit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NibResource+UIKit.swift"; sourceTree = "<group>"; };
@@ -70,6 +100,21 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		806E698E1C42BD9C00DE3A8B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		806E69981C42BD9C00DE3A8B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				806E699C1C42BD9C00DE3A8B /* Rswift.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		D592464A1C117A55007F94C7 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -134,7 +179,9 @@
 			isa = PBXGroup;
 			children = (
 				D592464E1C117A55007F94C7 /* Rswift.framework */,
-				D59246581C117A55007F94C7 /* RswiftTests.xctest */,
+				D59246581C117A55007F94C7 /* RswiftTests-iOS.xctest */,
+				806E69921C42BD9C00DE3A8B /* Rswift.framework */,
+				806E699B1C42BD9C00DE3A8B /* RswiftTests-tvOS.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -162,6 +209,13 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		806E698F1C42BD9C00DE3A8B /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		D592464B1C117A55007F94C7 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -173,9 +227,45 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		D592464D1C117A55007F94C7 /* Rswift */ = {
+		806E69911C42BD9C00DE3A8B /* Rswift-tvOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = D59246621C117A55007F94C7 /* Build configuration list for PBXNativeTarget "Rswift" */;
+			buildConfigurationList = 806E69A31C42BD9C00DE3A8B /* Build configuration list for PBXNativeTarget "Rswift-tvOS" */;
+			buildPhases = (
+				806E698D1C42BD9C00DE3A8B /* Sources */,
+				806E698E1C42BD9C00DE3A8B /* Frameworks */,
+				806E698F1C42BD9C00DE3A8B /* Headers */,
+				806E69901C42BD9C00DE3A8B /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Rswift-tvOS";
+			productName = "Rswift-tvOS";
+			productReference = 806E69921C42BD9C00DE3A8B /* Rswift.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		806E699A1C42BD9C00DE3A8B /* RswiftTests-tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 806E69A61C42BD9C00DE3A8B /* Build configuration list for PBXNativeTarget "RswiftTests-tvOS" */;
+			buildPhases = (
+				806E69971C42BD9C00DE3A8B /* Sources */,
+				806E69981C42BD9C00DE3A8B /* Frameworks */,
+				806E69991C42BD9C00DE3A8B /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				806E699E1C42BD9C00DE3A8B /* PBXTargetDependency */,
+			);
+			name = "RswiftTests-tvOS";
+			productName = "Rswift-tvOSTests";
+			productReference = 806E699B1C42BD9C00DE3A8B /* RswiftTests-tvOS.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		D592464D1C117A55007F94C7 /* Rswift-iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D59246621C117A55007F94C7 /* Build configuration list for PBXNativeTarget "Rswift-iOS" */;
 			buildPhases = (
 				D59246491C117A55007F94C7 /* Sources */,
 				D592464A1C117A55007F94C7 /* Frameworks */,
@@ -186,14 +276,14 @@
 			);
 			dependencies = (
 			);
-			name = Rswift;
+			name = "Rswift-iOS";
 			productName = Rswift;
 			productReference = D592464E1C117A55007F94C7 /* Rswift.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		D59246571C117A55007F94C7 /* RswiftTests */ = {
+		D59246571C117A55007F94C7 /* RswiftTests-iOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = D59246651C117A55007F94C7 /* Build configuration list for PBXNativeTarget "RswiftTests" */;
+			buildConfigurationList = D59246651C117A55007F94C7 /* Build configuration list for PBXNativeTarget "RswiftTests-iOS" */;
 			buildPhases = (
 				D59246541C117A55007F94C7 /* Sources */,
 				D59246551C117A55007F94C7 /* Frameworks */,
@@ -204,9 +294,9 @@
 			dependencies = (
 				D592465B1C117A55007F94C7 /* PBXTargetDependency */,
 			);
-			name = RswiftTests;
+			name = "RswiftTests-iOS";
 			productName = RswiftTests;
-			productReference = D59246581C117A55007F94C7 /* RswiftTests.xctest */;
+			productReference = D59246581C117A55007F94C7 /* RswiftTests-iOS.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */
@@ -215,10 +305,16 @@
 		D59246451C117A54007F94C7 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 0710;
+				LastSwiftUpdateCheck = 0720;
 				LastUpgradeCheck = 0710;
 				ORGANIZATIONNAME = "Mathijs Kadijk";
 				TargetAttributes = {
+					806E69911C42BD9C00DE3A8B = {
+						CreatedOnToolsVersion = 7.2;
+					};
+					806E699A1C42BD9C00DE3A8B = {
+						CreatedOnToolsVersion = 7.2;
+					};
 					D592464D1C117A55007F94C7 = {
 						CreatedOnToolsVersion = 7.1.1;
 					};
@@ -239,13 +335,29 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				D592464D1C117A55007F94C7 /* Rswift */,
-				D59246571C117A55007F94C7 /* RswiftTests */,
+				D592464D1C117A55007F94C7 /* Rswift-iOS */,
+				D59246571C117A55007F94C7 /* RswiftTests-iOS */,
+				806E69911C42BD9C00DE3A8B /* Rswift-tvOS */,
+				806E699A1C42BD9C00DE3A8B /* RswiftTests-tvOS */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		806E69901C42BD9C00DE3A8B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		806E69991C42BD9C00DE3A8B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		D592464C1C117A55007F94C7 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -263,6 +375,40 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		806E698D1C42BD9C00DE3A8B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				806E69AD1C42BDDA00DE3A8B /* ReuseIdentifierProtocol.swift in Sources */,
+				806E69B61C42BDE000DE3A8B /* UINib+NibResource.swift in Sources */,
+				806E69AA1C42BDDA00DE3A8B /* FontResource.swift in Sources */,
+				806E69B41C42BDE000DE3A8B /* UICollectionView+ReuseIdentifierProtocol.swift in Sources */,
+				806E69B11C42BDE000DE3A8B /* NibResource+UIKit.swift in Sources */,
+				806E69B71C42BDE000DE3A8B /* UIStoryboard+StoryboardResource.swift in Sources */,
+				806E69B81C42BDE000DE3A8B /* UIStoryboardSegue+StoryboardSegueIdentifierProtocol.swift in Sources */,
+				806E69AC1C42BDDA00DE3A8B /* NibResource.swift in Sources */,
+				806E69BA1C42BDE000DE3A8B /* UIViewController+NibResource.swift in Sources */,
+				806E69B51C42BDE000DE3A8B /* UIFont+FontResource.swift in Sources */,
+				806E69BB1C42BDE000DE3A8B /* UIViewController+StoryboardSegueIdentifierProtocol.swift in Sources */,
+				806E69B21C42BDE000DE3A8B /* StoryboardResourceWithInitialController+UIKit.swift in Sources */,
+				806E69AF1C42BDDA00DE3A8B /* StoryboardSegueIdentifierProtocol.swift in Sources */,
+				806E69AB1C42BDDA00DE3A8B /* Identifier.swift in Sources */,
+				806E69B01C42BDDA00DE3A8B /* Validatable.swift in Sources */,
+				806E69B31C42BDE000DE3A8B /* TypedStoryboardSegueInfo+UIStoryboardSegue.swift in Sources */,
+				806E69B91C42BDE000DE3A8B /* UITableView+ReuseIdentifierProtocol.swift in Sources */,
+				806E69AE1C42BDDA00DE3A8B /* StoryboardResource.swift in Sources */,
+				806E69A91C42BDDA00DE3A8B /* FileResource.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		806E69971C42BD9C00DE3A8B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				806E69BC1C42BDE300DE3A8B /* RswiftTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		D59246491C117A55007F94C7 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -300,14 +446,81 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		806E699E1C42BD9C00DE3A8B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 806E69911C42BD9C00DE3A8B /* Rswift-tvOS */;
+			targetProxy = 806E699D1C42BD9C00DE3A8B /* PBXContainerItemProxy */;
+		};
 		D592465B1C117A55007F94C7 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = D592464D1C117A55007F94C7 /* Rswift */;
+			target = D592464D1C117A55007F94C7 /* Rswift-iOS */;
 			targetProxy = D592465A1C117A55007F94C7 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		806E69A41C42BD9C00DE3A8B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Library/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = nl.mathijskadijk.rswift.library;
+				PRODUCT_NAME = Rswift;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.1;
+			};
+			name = Debug;
+		};
+		806E69A51C42BD9C00DE3A8B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Library/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = nl.mathijskadijk.rswift.library;
+				PRODUCT_NAME = Rswift;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.1;
+			};
+			name = Release;
+		};
+		806E69A71C42BD9C00DE3A8B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = LibraryTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = nl.mathijskadijk.RswiftTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = appletvos;
+				TVOS_DEPLOYMENT_TARGET = 9.1;
+			};
+			name = Debug;
+		};
+		806E69A81C42BD9C00DE3A8B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = LibraryTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = nl.mathijskadijk.RswiftTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = appletvos;
+				TVOS_DEPLOYMENT_TARGET = 9.1;
+			};
+			name = Release;
+		};
 		D59246601C117A55007F94C7 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -409,7 +622,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = nl.mathijskadijk.rswift.library;
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = Rswift;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
@@ -427,7 +640,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = nl.mathijskadijk.rswift.library;
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = Rswift;
 				SKIP_INSTALL = YES;
 			};
 			name = Release;
@@ -435,7 +648,7 @@
 		D59246661C117A55007F94C7 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				INFOPLIST_FILE = RswiftTests/Info.plist;
+				INFOPLIST_FILE = LibraryTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = nl.mathijskadijk.RswiftTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -445,7 +658,7 @@
 		D59246671C117A55007F94C7 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				INFOPLIST_FILE = RswiftTests/Info.plist;
+				INFOPLIST_FILE = LibraryTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = nl.mathijskadijk.RswiftTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -455,6 +668,22 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		806E69A31C42BD9C00DE3A8B /* Build configuration list for PBXNativeTarget "Rswift-tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				806E69A41C42BD9C00DE3A8B /* Debug */,
+				806E69A51C42BD9C00DE3A8B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		806E69A61C42BD9C00DE3A8B /* Build configuration list for PBXNativeTarget "RswiftTests-tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				806E69A71C42BD9C00DE3A8B /* Debug */,
+				806E69A81C42BD9C00DE3A8B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
 		D59246481C117A54007F94C7 /* Build configuration list for PBXProject "R.swift.Library" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -464,7 +693,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		D59246621C117A55007F94C7 /* Build configuration list for PBXNativeTarget "Rswift" */ = {
+		D59246621C117A55007F94C7 /* Build configuration list for PBXNativeTarget "Rswift-iOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				D59246631C117A55007F94C7 /* Debug */,
@@ -473,7 +702,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		D59246651C117A55007F94C7 /* Build configuration list for PBXNativeTarget "RswiftTests" */ = {
+		D59246651C117A55007F94C7 /* Build configuration list for PBXNativeTarget "RswiftTests-iOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				D59246661C117A55007F94C7 /* Debug */,

--- a/R.swift.Library.xcodeproj/xcshareddata/xcschemes/Rswift-iOS.xcscheme
+++ b/R.swift.Library.xcodeproj/xcshareddata/xcschemes/Rswift-iOS.xcscheme
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0710"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D592464D1C117A55007F94C7"
+               BuildableName = "Rswift.framework"
+               BlueprintName = "Rswift-iOS"
+               ReferencedContainer = "container:R.swift.Library.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D59246571C117A55007F94C7"
+               BuildableName = "RswiftTests-iOS.xctest"
+               BlueprintName = "RswiftTests-iOS"
+               ReferencedContainer = "container:R.swift.Library.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D592464D1C117A55007F94C7"
+            BuildableName = "Rswift.framework"
+            BlueprintName = "Rswift-iOS"
+            ReferencedContainer = "container:R.swift.Library.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D592464D1C117A55007F94C7"
+            BuildableName = "Rswift.framework"
+            BlueprintName = "Rswift-iOS"
+            ReferencedContainer = "container:R.swift.Library.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D592464D1C117A55007F94C7"
+            BuildableName = "Rswift.framework"
+            BlueprintName = "Rswift-iOS"
+            ReferencedContainer = "container:R.swift.Library.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/R.swift.Library.xcodeproj/xcshareddata/xcschemes/Rswift-tvOS.xcscheme
+++ b/R.swift.Library.xcodeproj/xcshareddata/xcschemes/Rswift-tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0720"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -14,9 +14,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "D592464D1C117A55007F94C7"
+               BlueprintIdentifier = "806E69911C42BD9C00DE3A8B"
                BuildableName = "Rswift.framework"
-               BlueprintName = "Rswift"
+               BlueprintName = "Rswift-tvOS"
                ReferencedContainer = "container:R.swift.Library.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -32,9 +32,9 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "D59246571C117A55007F94C7"
-               BuildableName = "RswiftTests.xctest"
-               BlueprintName = "RswiftTests"
+               BlueprintIdentifier = "806E699A1C42BD9C00DE3A8B"
+               BuildableName = "RswiftTests-tvOS.xctest"
+               BlueprintName = "RswiftTests-tvOS"
                ReferencedContainer = "container:R.swift.Library.xcodeproj">
             </BuildableReference>
          </TestableReference>
@@ -42,9 +42,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "D592464D1C117A55007F94C7"
+            BlueprintIdentifier = "806E69911C42BD9C00DE3A8B"
             BuildableName = "Rswift.framework"
-            BlueprintName = "Rswift"
+            BlueprintName = "Rswift-tvOS"
             ReferencedContainer = "container:R.swift.Library.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -64,9 +64,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "D592464D1C117A55007F94C7"
+            BlueprintIdentifier = "806E69911C42BD9C00DE3A8B"
             BuildableName = "Rswift.framework"
-            BlueprintName = "Rswift"
+            BlueprintName = "Rswift-tvOS"
             ReferencedContainer = "container:R.swift.Library.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -82,9 +82,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "D592464D1C117A55007F94C7"
+            BlueprintIdentifier = "806E69911C42BD9C00DE3A8B"
             BuildableName = "Rswift.framework"
-            BlueprintName = "Rswift"
+            BlueprintName = "Rswift-tvOS"
             ReferencedContainer = "container:R.swift.Library.xcodeproj">
          </BuildableReference>
       </MacroExpansion>


### PR DESCRIPTION
This PR ads a tvOS scheme, so it can be used for tvOS targets using Carthage.

For consistency the iOS scheme is renamed to `Rswift-iOS`, but the framework is still called `Rswift.framework` of course.

I needed to `import UIKit` at some places for it to work.
