### PR TITLE
Add StoryboardSegue

### DIFF
--- a/Library/Core/StoryboardSegueIdentifierProtocol.swift
+++ b/Library/Core/StoryboardSegueIdentifierProtocol.swift
@@ -42,6 +42,13 @@ public struct StoryboardSegueIdentifier<Segue, Source, Destination>: StoryboardS
   public init(identifier: String) {
     self.identifier = identifier
   }
+
+  /// Create a new StoryboardSegue based on the identifier and source view controller
+  public func storyboardSegueWithSource(sourceViewController: Source)
+    -> StoryboardSegue<Segue, Source, Destination>
+  {
+    return StoryboardSegue(identifier: self, sourceViewController: sourceViewController)
+  }
 }
 
 /// Typed segue information
@@ -66,4 +73,23 @@ public struct TypedStoryboardSegueInfo<Segue, Source, Destination>: StoryboardSe
 
   /// Segue source view controller
   public let sourceViewController: Source
+}
+
+/// Segue with identifier and source view controller
+public struct StoryboardSegue<Segue, Source, Destination> {
+  /// Identifier of this segue
+  public let identifier: StoryboardSegueIdentifier<Segue, Source, Destination>
+
+  /// Segue source view controller
+  public let sourceViewController: Source
+
+  /**
+   Create a new segue based on the identifier and source view controller
+
+   - returns: A new StoryboardSegue
+   */
+  public init(identifier: StoryboardSegueIdentifier<Segue, Source, Destination>, sourceViewController: Source) {
+    self.identifier = identifier
+    self.sourceViewController = sourceViewController
+  }
 }

--- a/Library/UIKit/UIViewController+StoryboardSegueIdentifierProtocol.swift
+++ b/Library/UIKit/UIViewController+StoryboardSegueIdentifierProtocol.swift
@@ -9,16 +9,22 @@
 import Foundation
 import UIKit
 
-public extension UIViewController {
+public protocol UIViewControllerType {
+  func performSegueWithIdentifier(identifier: String, sender: AnyObject?)
+}
+
+extension UIViewController: UIViewControllerType { }
+
+public extension UIViewControllerType {
   /**
-   Initiates the segue with the specified identifier (R.segue.*) from the current view controller's storyboard file.
-   
+   Initiates the segue with the specified identifier (R.segue.*) from the current view controller's storyboard file.
    - parameter identifier: The R.segue.* that identifies the triggered segue.
-   - parameter segue: The object that you want to use to initiate the segue. This object is made available for informational purposes during the actual segue.
-   
+   - parameter sender: The object that you want to use to initiate the segue. This object is made available for informational purposes during the actual segue.
    - SeeAlso: Library for typed block based segues: [tomlokhorst/SegueManager](https://github.com/tomlokhorst/SegueManager)
-  */
-  public func performSegueWithIdentifier<Identifier: StoryboardSegueIdentifierType>(identifier: Identifier, sender: AnyObject?) {
+   */
+  public func performSegueWithIdentifier<Segue, Destination>(
+    identifier: StoryboardSegueIdentifier<Segue, Self, Destination>,
+    sender: AnyObject?) {
     performSegueWithIdentifier(identifier.identifier, sender: sender)
   }
 }

--- a/Library/UIKit/UIViewController+StoryboardSegueIdentifierProtocol.swift
+++ b/Library/UIKit/UIViewController+StoryboardSegueIdentifierProtocol.swift
@@ -16,9 +16,16 @@ public extension UIViewController {
    - parameter identifier: The R.segue.* that identifies the triggered segue.
    - parameter segue: The object that you want to use to initiate the segue. This object is made available for informational purposes during the actual segue.
    
-   - SeeAlso: Library for typed block based segues: https://github.com/tomlokhorst/SegueManager
+   - SeeAlso: Library for typed block based segues: [tomlokhorst/SegueManager](https://github.com/tomlokhorst/SegueManager)
   */
   public func performSegueWithIdentifier<Identifier: StoryboardSegueIdentifierType>(identifier: Identifier, sender: AnyObject?) {
     performSegueWithIdentifier(identifier.identifier, sender: sender)
+  }
+}
+
+public extension StoryboardSegue where Source : UIViewController {
+  /// Performs the specified segue
+  public func performSegue(sender: AnyObject? = nil) {
+    sourceViewController.performSegueWithIdentifier(identifier.identifier, sender: sender)
   }
 }


### PR DESCRIPTION
Starting work on https://github.com/mac-cain13/R.swift/issues/158

With this, a segue (identifier & source) can be wrapped up in a new value, e.g.:

``` swift
let segueFromSecondToThird = R.segue.secondViewController.toThird.storyboardSegueWithSource(self)
```

And it can later on be performed:

``` swift
segueFromSecondToThird.performSegue()
```
