### PR TITLE
UITableView dequeue header/footer view typo

### DIFF
--- a/Library/UIKit/UITableView+ReuseIdentifierProtocol.swift
+++ b/Library/UIKit/UITableView+ReuseIdentifierProtocol.swift
@@ -44,7 +44,7 @@ public extension UITableView {
    
    - returns: A UITableViewHeaderFooterView object with the associated identifier or nil if no such object exists in the reusable view queue or if it couldn't be cast correctly.
    */
-  public func dequeueReusableHeaderFooterViewWithIdentifier<Identifier: ReuseIdentifierType where Identifier.ReusableType: UIView>(identifier: Identifier) -> Identifier.ReusableType? {
+  public func dequeueReusableHeaderFooterViewWithIdentifier<Identifier: ReuseIdentifierType where Identifier.ReusableType: UITableViewHeaderFooterView>(identifier: Identifier) -> Identifier.ReusableType? {
     return dequeueReusableHeaderFooterViewWithIdentifier(identifier.identifier) as? Identifier.ReusableType
   }
 

--- a/Library/UIKit/UITableView+ReuseIdentifierProtocol.swift
+++ b/Library/UIKit/UITableView+ReuseIdentifierProtocol.swift
@@ -44,7 +44,7 @@ public extension UITableView {
    
    - returns: A UITableViewHeaderFooterView object with the associated identifier or nil if no such object exists in the reusable view queue or if it couldn't be cast correctly.
    */
-  public func dequeueReusableHeaderFooterViewWithIdentifier<Identifier: ReuseIdentifierType where Identifier.ReusableType: UITableViewCell>(identifier: Identifier) -> Identifier.ReusableType? {
+  public func dequeueReusableHeaderFooterViewWithIdentifier<Identifier: ReuseIdentifierType where Identifier.ReusableType: UIView>(identifier: Identifier) -> Identifier.ReusableType? {
     return dequeueReusableHeaderFooterViewWithIdentifier(identifier.identifier) as? Identifier.ReusableType
   }
 


### PR DESCRIPTION
Fixes a typo that causes views of the correct superclass to not be dequeued as UITableView header/footer views
