### PR TITLE
Avoid dirty submodules for Carthage users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ fastlane/report.xml
 fastlane/test_output
 fastlane/settoken.sh
 /build
+Carthage/Build


### PR DESCRIPTION
Carthage creates the directory `Carthage/Build` for every submodules when using `carthage update --submodule`. This behavior leads to dirty submodule, because `.gitignore` of R.swift.Library does not include `Carthage/Build`. After this patch, `Carthage/Build` in R.swift.Library will be ignored, so the submodule do not get dirty.


# How to test this patch
You can test this patch by using [the sample app](https://github.com/Kuniwak/SampleAppForRswiftViaCarthage).


## Before this patch

```console
$ git checkout master
$ carthage update --use-submodules
...

$ git status
On branch master
Your branch is up-to-date with 'origin/master'.
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)
  (commit or discard the untracked or modified content in submodules)

        modified:   Carthage/Checkouts/R.swift.Library (untracked content)

no changes added to commit (use "git add" and/or "git commit -a")

$ git diff
diff --git a/Carthage/Checkouts/R.swift.Library b/Carthage/Checkouts/R.swift.Library
--- a/Carthage/Checkouts/R.swift.Library
+++ b/Carthage/Checkouts/R.swift.Library
@@ -1 +1 @@
-Subproject commit b520035ddad4a47eb580b576ba5c6fb72df51c97
+Subproject commit b520035ddad4a47eb580b576ba5c6fb72df51c97-dirty 👈
```

## After this patch

```console
$ git checkout patched
$ carthage update --use-submodules
...

$ git status
On branch patched
Your branch is up-to-date with 'origin/patched'.
nothing to commit, working tree clean 🎉
```