### PR TITLE
ColorResource for color assets

### DIFF
--- a/Library/Core/ColorPaletteItemResource.swift
+++ b/Library/Core/ColorPaletteItemResource.swift
@@ -1,0 +1,55 @@
+//
+//  ColorPaletteItemResource.swift
+//  R.swift.Library
+//
+//  Created by Tom Lokhorst on 2016-03-13.
+//  From: https://github.com/mac-cain13/R.swift.Library
+//  License: MIT License
+//
+
+import Foundation
+
+public protocol ColorPaletteItemResourceType {
+
+  /// Name of the color
+  var name: String { get }
+
+  /// Red componenent of color
+  var red: CGFloat { get }
+
+  /// Green componenent of color
+  var green: CGFloat { get }
+
+  /// Blue componenent of color
+  var blue: CGFloat { get }
+
+  /// Alpha componenent of color
+  var alpha: CGFloat { get }
+}
+
+@available(*, deprecated: 11, message: "Use color assets instead")
+public struct ColorPaletteItemResource: ColorPaletteItemResourceType {
+
+  /// Name of the color
+  public let name: String
+
+  /// Red componenent of color
+  public let red: CGFloat
+
+  /// Green componenent of color
+  public let green: CGFloat
+
+  /// Blue componenent of color
+  public let blue: CGFloat
+
+  /// Alpha componenent of color
+  public let alpha: CGFloat
+
+  public init(name: String, red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat) {
+    self.name = name
+    self.red = red
+    self.green = green
+    self.blue = blue
+    self.alpha = alpha
+  }
+}

--- a/Library/Core/ColorResource.swift
+++ b/Library/Core/ColorResource.swift
@@ -11,44 +11,23 @@ import Foundation
 
 public protocol ColorResourceType {
 
+  /// Bundle this color is in
+  var bundle: Bundle { get }
+
   /// Name of the color
   var name: String { get }
-
-  /// Red componenent of color
-  var red: CGFloat { get }
-
-  /// Green componenent of color
-  var green: CGFloat { get }
-
-  /// Blue componenent of color
-  var blue: CGFloat { get }
-
-  /// Alpha componenent of color
-  var alpha: CGFloat { get }
 }
 
 public struct ColorResource: ColorResourceType {
 
+  /// Bundle this color is in
+  public let bundle: Bundle
+
   /// Name of the color
   public let name: String
 
-  /// Red componenent of color
-  public let red: CGFloat
-
-  /// Green componenent of color
-  public let green: CGFloat
-
-  /// Blue componenent of color
-  public let blue: CGFloat
-
-  /// Alpha componenent of color
-  public let alpha: CGFloat
-
-  public init(name: String, red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat) {
+  public init(bundle: Bundle, name: String) {
+    self.bundle = bundle
     self.name = name
-    self.red = red
-    self.green = green
-    self.blue = blue
-    self.alpha = alpha
   }
 }

--- a/Library/UIKit/ColorPaletteItemResource+UIKit.swift
+++ b/Library/UIKit/ColorPaletteItemResource+UIKit.swift
@@ -1,5 +1,5 @@
 //
-//  ColorResource+UIKit.swift
+//  ColorPaletteItemResource+UIKit.swift
 //  R.swift.Library
 //
 //  Created by Tom Lokhorst on 2016-04-23.
@@ -9,11 +9,11 @@
 
 import UIKit
 
-public extension ColorResourceType {
+public extension ColorPaletteItemResourceType {
   /**
    Returns the a UIColor
 
-   - returns: A UIColor for this color resource
+   - returns: A UIColor for this color palette item resource
    */
   func color() -> UIColor {
     return UIColor(red: red, green: green, blue: blue, alpha: alpha)

--- a/Library/UIKit/UIColor+ColorResource.swift
+++ b/Library/UIKit/UIColor+ColorResource.swift
@@ -1,0 +1,26 @@
+//
+//  UIColor+ColorResource.swift
+//  R.swift.Library
+//
+//  Created by Tom Lokhorst on 2017-06-06.
+//  From: https://github.com/mac-cain13/R.swift.Library
+//  License: MIT License
+//
+
+import UIKit
+
+@available(iOS 11.0, *)
+@available(tvOS 11.0, *)
+public extension UIColor {
+  /**
+   Returns the color from this resource (R.color.*) that is compatible with the trait collection.
+
+   - parameter resource: The resource you want the image of (R.color.*)
+   - parameter traitCollection: Traits that describe the desired color to retrieve, pass nil to use traits that describe the main screen.
+
+   - returns: A color that exactly or best matches the desired traits with the given resource (R.color.*), or nil if no suitable color was found.
+   */
+  public convenience init?(resource: ColorResourceType, compatibleWith traitCollection: UITraitCollection? = nil) {
+    self.init(named: resource.name, in: resource.bundle, compatibleWith: traitCollection)
+  }
+}

--- a/R.swift.Library.xcodeproj/project.pbxproj
+++ b/R.swift.Library.xcodeproj/project.pbxproj
@@ -63,13 +63,17 @@
 		E20F34A71C92B44100338F81 /* Data+FileResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = E20F34A61C92B44100338F81 /* Data+FileResource.swift */; };
 		E22D43671C95EEA100692FFF /* ColorResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = E22D43661C95EEA100692FFF /* ColorResource.swift */; };
 		E24720CA1C96B4D100DF291D /* ColorResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = E22D43661C95EEA100692FFF /* ColorResource.swift */; };
-		E250BE941CCBCEB100CC71DE /* ColorResource+UIKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = E250BE931CCBCEB100CC71DE /* ColorResource+UIKit.swift */; };
-		E250BE951CCBF58200CC71DE /* ColorResource+UIKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = E250BE931CCBCEB100CC71DE /* ColorResource+UIKit.swift */; };
 		E250BE971CCBF60300CC71DE /* StringResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = E250BE961CCBF60300CC71DE /* StringResource.swift */; };
 		E250BE991CCBF7E900CC71DE /* StringResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = E250BE961CCBF60300CC71DE /* StringResource.swift */; };
 		E2B0AF361D8142A400A7196C /* Core+Migration.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2B0AF351D8142A400A7196C /* Core+Migration.swift */; };
 		E2B0AF381D8142BF00A7196C /* UIKit+Migration.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2B0AF371D8142BF00A7196C /* UIKit+Migration.swift */; };
 		E2B0AF3A1D81483900A7196C /* Foundation+Migration.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2B0AF391D81483900A7196C /* Foundation+Migration.swift */; };
+		E2CA68EB1EE75151009C4DB4 /* ColorPaletteItemResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2CA68EA1EE75151009C4DB4 /* ColorPaletteItemResource.swift */; };
+		E2CA68ED1EE751A9009C4DB4 /* ColorPaletteItemResource+UIKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2CA68EC1EE751A9009C4DB4 /* ColorPaletteItemResource+UIKit.swift */; };
+		E2CA68EF1EE75992009C4DB4 /* UIColor+ColorResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2CA68EE1EE75992009C4DB4 /* UIColor+ColorResource.swift */; };
+		E2CA68F01EE759C3009C4DB4 /* ColorPaletteItemResource+UIKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2CA68EC1EE751A9009C4DB4 /* ColorPaletteItemResource+UIKit.swift */; };
+		E2CA68F11EE75A02009C4DB4 /* ColorPaletteItemResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2CA68EA1EE75151009C4DB4 /* ColorPaletteItemResource.swift */; };
+		E2CA68F21EE75A49009C4DB4 /* UIColor+ColorResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2CA68EE1EE75992009C4DB4 /* UIColor+ColorResource.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -123,11 +127,13 @@
 		D5E435AC1C3D00770091090C /* FileResource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileResource.swift; sourceTree = "<group>"; };
 		E20F34A61C92B44100338F81 /* Data+FileResource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Data+FileResource.swift"; sourceTree = "<group>"; };
 		E22D43661C95EEA100692FFF /* ColorResource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ColorResource.swift; sourceTree = "<group>"; };
-		E250BE931CCBCEB100CC71DE /* ColorResource+UIKit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ColorResource+UIKit.swift"; sourceTree = "<group>"; };
 		E250BE961CCBF60300CC71DE /* StringResource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringResource.swift; sourceTree = "<group>"; };
 		E2B0AF351D8142A400A7196C /* Core+Migration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Core+Migration.swift"; sourceTree = "<group>"; };
 		E2B0AF371D8142BF00A7196C /* UIKit+Migration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIKit+Migration.swift"; sourceTree = "<group>"; };
 		E2B0AF391D81483900A7196C /* Foundation+Migration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Foundation+Migration.swift"; sourceTree = "<group>"; };
+		E2CA68EA1EE75151009C4DB4 /* ColorPaletteItemResource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorPaletteItemResource.swift; sourceTree = "<group>"; };
+		E2CA68EC1EE751A9009C4DB4 /* ColorPaletteItemResource+UIKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ColorPaletteItemResource+UIKit.swift"; sourceTree = "<group>"; };
+		E2CA68EE1EE75992009C4DB4 /* UIColor+ColorResource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+ColorResource.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -167,20 +173,21 @@
 		D543F9C21C14987000D16A0C /* UIKit */ = {
 			isa = PBXGroup;
 			children = (
-				E250BE931CCBCEB100CC71DE /* ColorResource+UIKit.swift */,
+				E2CA68EC1EE751A9009C4DB4 /* ColorPaletteItemResource+UIKit.swift */,
 				D5E435A81C3CFB460091090C /* NibResource+UIKit.swift */,
 				D57E1EB81C3E4C1A00DDA68F /* StoryboardResourceWithInitialController+UIKit.swift */,
 				D543F9CE1C149C0A00D16A0C /* TypedStoryboardSegueInfo+UIStoryboardSegue.swift */,
 				D543F9C51C14992000D16A0C /* UICollectionView+ReuseIdentifierProtocol.swift */,
+				E2CA68EE1EE75992009C4DB4 /* UIColor+ColorResource.swift */,
 				D57E1EB41C3D774000DDA68F /* UIFont+FontResource.swift */,
 				D553F5861C44170E00885232 /* UIImage+ImageResource.swift */,
+				E2B0AF371D8142BF00A7196C /* UIKit+Migration.swift */,
 				D5588CAA1C3F9DBE00912F97 /* UINib+NibResource.swift */,
 				D57E1EBA1C3E4C4300DDA68F /* UIStoryboard+StoryboardResource.swift */,
 				D51335281C95A79B0014C9D4 /* UIStoryboard+StoryboardViewControllerResource.swift */,
 				D543F9C31C1498FB00D16A0C /* UITableView+ReuseIdentifierProtocol.swift */,
 				D543F9C71C14995800D16A0C /* UIViewController+NibResource.swift */,
 				D543F9C91C14998800D16A0C /* UIViewController+StoryboardSegueIdentifierProtocol.swift */,
-				E2B0AF371D8142BF00A7196C /* UIKit+Migration.swift */,
 			);
 			path = UIKit;
 			sourceTree = "<group>";
@@ -188,7 +195,9 @@
 		D543F9CD1C1499CF00D16A0C /* Core */ = {
 			isa = PBXGroup;
 			children = (
+				E2CA68EA1EE75151009C4DB4 /* ColorPaletteItemResource.swift */,
 				E22D43661C95EEA100692FFF /* ColorResource.swift */,
+				E2B0AF351D8142A400A7196C /* Core+Migration.swift */,
 				D5E435AC1C3D00770091090C /* FileResource.swift */,
 				D57E1EB21C3D762300DDA68F /* FontResource.swift */,
 				D543F9BA1C1497EB00D16A0C /* Identifier.swift */,
@@ -200,7 +209,6 @@
 				D51335261C959DF20014C9D4 /* StoryboardViewControllerResource.swift */,
 				E250BE961CCBF60300CC71DE /* StringResource.swift */,
 				D53F19231C229D7200AE2FAD /* Validatable.swift */,
-				E2B0AF351D8142A400A7196C /* Core+Migration.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -441,6 +449,7 @@
 				D513352B1C95B7620014C9D4 /* UIStoryboard+StoryboardViewControllerResource.swift in Sources */,
 				D513352C1C95C61E0014C9D4 /* Data+FileResource.swift in Sources */,
 				806E69AD1C42BDDA00DE3A8B /* ReuseIdentifierProtocol.swift in Sources */,
+				E2CA68F21EE75A49009C4DB4 /* UIColor+ColorResource.swift in Sources */,
 				806E69B61C42BDE000DE3A8B /* UINib+NibResource.swift in Sources */,
 				806E69AA1C42BDDA00DE3A8B /* FontResource.swift in Sources */,
 				806E69B41C42BDE000DE3A8B /* UICollectionView+ReuseIdentifierProtocol.swift in Sources */,
@@ -459,10 +468,11 @@
 				806E69B01C42BDDA00DE3A8B /* Validatable.swift in Sources */,
 				806E69B31C42BDE000DE3A8B /* TypedStoryboardSegueInfo+UIStoryboardSegue.swift in Sources */,
 				E250BE991CCBF7E900CC71DE /* StringResource.swift in Sources */,
+				E2CA68F01EE759C3009C4DB4 /* ColorPaletteItemResource+UIKit.swift in Sources */,
 				D5728B321C4D541500E38168 /* Bundle+FileResource.swift in Sources */,
-				E250BE951CCBF58200CC71DE /* ColorResource+UIKit.swift in Sources */,
 				806E69B91C42BDE000DE3A8B /* UITableView+ReuseIdentifierProtocol.swift in Sources */,
 				806E69AE1C42BDDA00DE3A8B /* StoryboardResource.swift in Sources */,
+				E2CA68F11EE75A02009C4DB4 /* ColorPaletteItemResource.swift in Sources */,
 				806E69A91C42BDDA00DE3A8B /* FileResource.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -482,13 +492,16 @@
 				D543F9CA1C14998800D16A0C /* UIViewController+StoryboardSegueIdentifierProtocol.swift in Sources */,
 				D51335291C95A79B0014C9D4 /* UIStoryboard+StoryboardViewControllerResource.swift in Sources */,
 				D5E435AD1C3D00770091090C /* FileResource.swift in Sources */,
+				E2CA68EB1EE75151009C4DB4 /* ColorPaletteItemResource.swift in Sources */,
 				D543F9BB1C1497EB00D16A0C /* Identifier.swift in Sources */,
+				E2CA68ED1EE751A9009C4DB4 /* ColorPaletteItemResource+UIKit.swift in Sources */,
 				D57E1EB71C3E482A00DDA68F /* StoryboardResource.swift in Sources */,
 				D57E1EBB1C3E4C4300DDA68F /* UIStoryboard+StoryboardResource.swift in Sources */,
 				D57E1EB31C3D762300DDA68F /* FontResource.swift in Sources */,
 				D57E1EB91C3E4C1A00DDA68F /* StoryboardResourceWithInitialController+UIKit.swift in Sources */,
 				D543F9BD1C14980600D16A0C /* ReuseIdentifierProtocol.swift in Sources */,
 				D543F9C11C14984300D16A0C /* NibResource.swift in Sources */,
+				E2CA68EF1EE75992009C4DB4 /* UIColor+ColorResource.swift in Sources */,
 				D553F5851C44157000885232 /* ImageResource.swift in Sources */,
 				E2B0AF381D8142BF00A7196C /* UIKit+Migration.swift in Sources */,
 				E20F34A71C92B44100338F81 /* Data+FileResource.swift in Sources */,
@@ -505,7 +518,6 @@
 				E2B0AF361D8142A400A7196C /* Core+Migration.swift in Sources */,
 				E250BE971CCBF60300CC71DE /* StringResource.swift in Sources */,
 				D543F9CF1C149C0A00D16A0C /* TypedStoryboardSegueInfo+UIStoryboardSegue.swift in Sources */,
-				E250BE941CCBCEB100CC71DE /* ColorResource+UIKit.swift in Sources */,
 				D543F9C41C1498FB00D16A0C /* UITableView+ReuseIdentifierProtocol.swift in Sources */,
 				D56DC7731C42B65C00623437 /* Bundle+FileResource.swift in Sources */,
 				D53F19241C229D7200AE2FAD /* Validatable.swift in Sources */,


### PR DESCRIPTION
⚠️ **Breaking change!**

Renames previous `ColorResource` for .clr resources to `ColorPaletteItemResource`, marked as deprecated.

Introduces new `ColorResource`.