### PR TITLE
Fix compilation for static linking

### DIFF
--- a/Library/Core/ColorPaletteItemResource.swift
+++ b/Library/Core/ColorPaletteItemResource.swift
@@ -7,7 +7,7 @@
 //  License: MIT License
 //
 
-import Foundation
+import CoreGraphics
 
 public protocol ColorPaletteItemResourceType {
 


### PR DESCRIPTION
Compilation fails when framework linked as static: see podspec attribute: `s.static_framework = true`