### PR TITLE
Add Support for Swift Package Manager (Minor Update)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ fastlane/test_output
 fastlane/settoken.sh
 /build
 Carthage/Build
+.swiftpm

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,9 @@ import PackageDescription
 let package = Package(
     name: "R.swift.Library",
     platforms: [
-        .iOS(.v8)
+        .iOS(.v8),
+        .tvOS(.v9),
+        .watchOS(.v2),
     ],
     products: [
         .library(name: "Rswift", targets: ["Rswift"])

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version:5.0
+
+import PackageDescription
+
+let package = Package(
+    name: "R.swift.Library",
+    platforms: [
+        .iOS(.v8)
+    ],
+    products: [
+        .library(name: "Rswift", targets: ["Rswift"])
+    ],
+    targets: [
+        .target(name: "Rswift", path: "Library")
+    ]
+)

--- a/Readme.md
+++ b/Readme.md
@@ -20,6 +20,15 @@ _**Be aware:** If you just want to use R.swift follow the [installation instruct
 1. Add `github "mac-cain13/R.swift.Library"` to your [Cartfile](https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#cartfile)
 2. Run `carthage`
 
+### Swift Package Manager (Requires Xcode 11)
+
+1. Open your Xcode project.
+2. Select `File > Swift Packages > Add Package Dependency...`
+3. Paste `https://github.com/mac-cain13/R.swift.Library` to the text field and click on the `Next` button.
+4. Choose appropriate version and click on the `Next` button. (If you need latest one, just click on the `Next` button.)
+5. Confirm that `Rswift` in the Package Product column is checked and your app's name is selected in the Add to Target column.
+6. Click on the `Next` button.
+
 ### Manually
 
 _As an embedded framework using git submodules._


### PR DESCRIPTION
This PR includes the previous pull request from @tkhp and adds the following minor modifications:

- adds the other supported platforms (tvOS and watchOS) to the Package.swift file (these are listed as being supporting in the .podspec)
- adds `.swiftpm` to the `.gitignore` file (pretty sure these should be ignored)

As a refresher, @tkhp submitted #33:

> As of Xcode 11, Xcode has Swift packages integration so we can now install R.swift.Library in Xcode by Swift Package Manager.
> I wrote a basic Package.swift and a manual to install R.swift.Library with Xcode's Swift packages integration.
> I've tested it and migrated from Carthage in my private projects, and everything works well.

I can also confirm this works great. Hopefully these will be accepted soon.

Thanks!