### PR TITLE
FIX Using in own SPM (allowed builds for macOS)

### DIFF
--- a/Library/UIKit/NibResource+UIKit.swift
+++ b/Library/UIKit/NibResource+UIKit.swift
@@ -7,7 +7,7 @@
 //  License: MIT License
 //
 
-#if !os(watchOS)
+#if canImport(UIKit)
 import Foundation
 import UIKit
 

--- a/Library/UIKit/StoryboardResourceWithInitialController+UIKit.swift
+++ b/Library/UIKit/StoryboardResourceWithInitialController+UIKit.swift
@@ -7,7 +7,7 @@
 //  License: MIT License
 //
 
-#if !os(watchOS)
+#if canImport(UIKit)
 import Foundation
 import UIKit
 

--- a/Library/UIKit/TypedStoryboardSegueInfo+UIStoryboardSegue.swift
+++ b/Library/UIKit/TypedStoryboardSegueInfo+UIStoryboardSegue.swift
@@ -7,7 +7,7 @@
 //  License: MIT License
 //
 
-#if !os(watchOS)
+#if canImport(UIKit)
 import Foundation
 import UIKit
 

--- a/Library/UIKit/UICollectionView+ReuseIdentifierProtocol.swift
+++ b/Library/UIKit/UICollectionView+ReuseIdentifierProtocol.swift
@@ -7,7 +7,7 @@
 //  License: MIT License
 //
 
-#if !os(watchOS)
+#if canImport(UIKit)
 import Foundation
 import UIKit
 

--- a/Library/UIKit/UIColor+ColorResource.swift
+++ b/Library/UIKit/UIColor+ColorResource.swift
@@ -7,6 +7,7 @@
 //  License: MIT License
 //
 
+#if canImport(UIKit)
 import UIKit
 
 @available(iOS 11.0, *)
@@ -41,3 +42,4 @@ public extension UIColor {
   }
   #endif
 }
+#endif

--- a/Library/UIKit/UIFont+FontResource.swift
+++ b/Library/UIKit/UIFont+FontResource.swift
@@ -7,6 +7,7 @@
 //  License: MIT License
 //
 
+#if canImport(UIKit)
 import Foundation
 import UIKit
 
@@ -23,3 +24,4 @@ public extension UIFont {
     self.init(name: resource.fontName, size: size)
   }
 }
+#endif

--- a/Library/UIKit/UIImage+ImageResource.swift
+++ b/Library/UIKit/UIImage+ImageResource.swift
@@ -7,6 +7,7 @@
 //  License: MIT License
 //
 
+#if canImport(UIKit)
 import UIKit
 
 public extension UIImage {
@@ -38,3 +39,4 @@ public extension UIImage {
   }
   #endif
 }
+#endif

--- a/Library/UIKit/UINib+NibResource.swift
+++ b/Library/UIKit/UINib+NibResource.swift
@@ -7,7 +7,7 @@
 //  License: MIT License
 //
 
-#if !os(watchOS)
+#if canImport(UIKit)
 import UIKit
 
 public extension UINib {

--- a/Library/UIKit/UIStoryboard+StoryboardResource.swift
+++ b/Library/UIKit/UIStoryboard+StoryboardResource.swift
@@ -7,7 +7,7 @@
 //  License: MIT License
 //
 
-#if !os(watchOS)
+#if canImport(UIKit)
 import UIKit
 
 public extension UIStoryboard {

--- a/Library/UIKit/UIStoryboard+StoryboardViewControllerResource.swift
+++ b/Library/UIKit/UIStoryboard+StoryboardViewControllerResource.swift
@@ -7,7 +7,7 @@
 //  License: MIT License
 //
 
-#if !os(watchOS)
+#if canImport(UIKit)
 import Foundation
 import UIKit
 

--- a/Library/UIKit/UITableView+ReuseIdentifierProtocol.swift
+++ b/Library/UIKit/UITableView+ReuseIdentifierProtocol.swift
@@ -7,7 +7,7 @@
 //  License: MIT License
 //
 
-#if !os(watchOS)
+#if canImport(UIKit)
 import Foundation
 import UIKit
 

--- a/Library/UIKit/UIViewController+NibResource.swift
+++ b/Library/UIKit/UIViewController+NibResource.swift
@@ -7,7 +7,7 @@
 //  License: MIT License
 //
 
-#if !os(watchOS)
+#if canImport(UIKit)
 import Foundation
 import UIKit
 

--- a/Library/UIKit/UIViewController+StoryboardSegueIdentifierProtocol.swift
+++ b/Library/UIKit/UIViewController+StoryboardSegueIdentifierProtocol.swift
@@ -7,7 +7,7 @@
 //  License: MIT License
 //
 
-#if !os(watchOS)
+#if canImport(UIKit)
 import Foundation
 import UIKit
 


### PR DESCRIPTION
Fixed using in own SPM - couldn't be builded for macOS since it doesn't support UIKit, which was imported several times.