### PR TITLE
Bundle resources support

### DIFF
--- a/Library/Core/ColorResource.swift
+++ b/Library/Core/ColorResource.swift
@@ -12,7 +12,7 @@ import Foundation
 public protocol ColorResourceType {
 
   /// Bundle this color is in
-  var bundle: Bundle { get }
+  var bundle: Bundle? { get }
 
   /// Name of the color
   var name: String { get }
@@ -21,12 +21,12 @@ public protocol ColorResourceType {
 public struct ColorResource: ColorResourceType {
 
   /// Bundle this color is in
-  public let bundle: Bundle
+  public let bundle: Bundle?
 
   /// Name of the color
   public let name: String
 
-  public init(bundle: Bundle, name: String) {
+  public init(bundle: Bundle?, name: String) {
     self.bundle = bundle
     self.name = name
   }

--- a/Library/Core/FileResource.swift
+++ b/Library/Core/FileResource.swift
@@ -12,7 +12,7 @@ import Foundation
 public protocol FileResourceType {
 
   /// Bundle this file is in
-  var bundle: Bundle { get }
+  var bundle: Bundle? { get }
 
   /// Name of the file file on disk
   var name: String { get }
@@ -33,7 +33,7 @@ public extension FileResourceType {
    - returns: The full pathname for this resource or nil if the file could not be located.
    */
   func path() -> String? {
-    return bundle.path(forResource: self)
+    return bundle?.path(forResource: self)
   }
 
   /**
@@ -42,13 +42,13 @@ public extension FileResourceType {
    - returns: The file URL for this resource or nil if the file could not be located.
    */
   func url() -> URL? {
-    return bundle.url(forResource: self)
+    return bundle?.url(forResource: self)
   }
 }
 
 public struct FileResource: FileResourceType {
   /// Bundle this file is in
-  public let bundle: Bundle
+  public let bundle: Bundle?
 
   /// Name of the file on disk, without the pathExtension
   public let name: String
@@ -56,7 +56,7 @@ public struct FileResource: FileResourceType {
   /// Extension of the file on disk
   public let pathExtension: String
 
-  public init(bundle: Bundle, name: String, pathExtension: String) {
+  public init(bundle: Bundle?, name: String, pathExtension: String) {
     self.bundle = bundle
     self.name = name
     self.pathExtension = pathExtension

--- a/Library/Core/ImageResource.swift
+++ b/Library/Core/ImageResource.swift
@@ -12,7 +12,7 @@ import Foundation
 public protocol ImageResourceType {
 
   /// Bundle this image is in
-  var bundle: Bundle { get }
+  var bundle: Bundle? { get }
 
   /// Name of the image
   var name: String { get }
@@ -21,12 +21,12 @@ public protocol ImageResourceType {
 public struct ImageResource: ImageResourceType {
 
   /// Bundle this image is in
-  public let bundle: Bundle
+  public let bundle: Bundle?
 
   /// Name of the image
   public let name: String
 
-  public init(bundle: Bundle, name: String) {
+  public init(bundle: Bundle?, name: String) {
     self.bundle = bundle
     self.name = name
   }

--- a/Library/Core/NibResource.swift
+++ b/Library/Core/NibResource.swift
@@ -13,7 +13,7 @@ import Foundation
 public protocol NibResourceType {
 
   /// Bundle this nib is in or nil for main bundle
-  var bundle: Bundle { get }
+  var bundle: Bundle? { get }
 
   /// Name of the nib file on disk
   var name: String { get }

--- a/Library/Core/StoryboardResource.swift
+++ b/Library/Core/StoryboardResource.swift
@@ -12,7 +12,7 @@ import Foundation
 public protocol StoryboardResourceType {
 
   /// Bundle this storyboard is in
-  var bundle: Bundle { get }
+  var bundle: Bundle? { get }
 
   /// Name of the storyboard file on disk
   var name: String { get }

--- a/Library/Core/StringResource.swift
+++ b/Library/Core/StringResource.swift
@@ -18,7 +18,7 @@ public protocol StringResourceType {
   var tableName: String { get }
 
   /// Bundle this string is in
-  var bundle: Bundle { get }
+  var bundle: Bundle? { get }
 
   /// Locales of the a localizable string
   var locales: [String] { get }
@@ -36,7 +36,7 @@ public struct StringResource: StringResourceType {
   public let tableName: String
 
   /// Bundle this string is in
-  public let bundle: Bundle
+  public let bundle: Bundle?
 
   /// Locales of the a localizable string
   public let locales: [String]
@@ -44,7 +44,7 @@ public struct StringResource: StringResourceType {
   /// Comment directly before and/or after the string, if any
   public let comment: String?
 
-  public init(key: String, tableName: String, bundle: Bundle, locales: [String], comment: String?) {
+  public init(key: String, tableName: String, bundle: Bundle?, locales: [String], comment: String?) {
     self.key = key
     self.tableName = tableName
     self.bundle = bundle


### PR DESCRIPTION
Make all references to `Bundle` optional in all *`Resource` types, as needed for bundle resources support.